### PR TITLE
[FEAT]: add API to split DM according to mma_atom (if need)

### DIFF
--- a/examples/81_demo_test/CMakeLists.txt
+++ b/examples/81_demo_test/CMakeLists.txt
@@ -53,3 +53,8 @@ cutlass_example_add_executable(
   apc_demo
   apc_demo.cu
   )
+
+cutlass_example_add_executable(
+  apc_mma_splitDM_demo
+  apc_mma_splitDM_demo.cu
+  )

--- a/examples/81_demo_test/apc_mma_splitDM_demo.cu
+++ b/examples/81_demo_test/apc_mma_splitDM_demo.cu
@@ -1,0 +1,223 @@
+/**
+ * in this demo, mma can split DM according to mma_atom shape.
+ */
+#include <cstdlib>
+#include <cstdio>
+#include <cassert>
+
+#include <thrust/host_vector.h>
+#include <thrust/device_vector.h>
+
+#include <cute/tensor.hpp>
+
+#include "cutlass/cluster_launch.hpp"
+#include "cutlass/arch/barrier.h"
+#include "cutlass/pipeline/ma100_pipeline.hpp"
+#include <cute/arch/mma_aurora_desc.hpp>
+#include <cute/arch/mma_aurora_gmma.hpp>
+
+#include "cutlass/util/print_error.hpp"
+#include "cutlass/util/GPU_Clock.hpp"
+#include "cutlass/util/helper_cuda.hpp"
+#include "cutlass/device_kernel.h"
+
+using namespace cute;
+
+auto bP = Int<  2>{};  // Pipeline
+
+template <class ElementC,
+          class SmemLayoutC>  // (N,K,P)
+struct SharedStorage
+{
+  array_aligned<ElementC, size_v<SmemLayoutC>> smem_C;
+};
+
+
+template <class ProblemShape, class CtaTiler,
+          class SmemLayoutA,
+          class SmemLayoutB,class SmemLayoutC,
+          class TC, class CStride, class TiledMma>
+__global__ static
+void
+gemm_device(ProblemShape shape_MNK, CtaTiler cta_tiler,
+            TC      * C, CStride dC, TiledMma mma)
+{
+  // Preconditions
+  //
+  // Full and Tiled Tensors
+  //
+
+  // Represent the full tensors
+  auto [M, N, K] = shape_MNK;
+  Tensor mC = make_tensor(make_gmem_ptr(C), make_shape(M,N), dC);      // (M,N)
+
+  // Get the appropriate blocks for this thread block
+  auto cta_coord = make_coord(blockIdx.x, blockIdx.y, _);              // (m,n,k)
+
+  Tensor gC = local_tile(mC, cta_tiler, cta_coord, Step<_1,_1, X>{});  // (BLK_M,BLK_N)
+
+  // Shared memory tensors
+  extern __shared__ char shared_memory[];
+  using SharedStorage = SharedStorage<TC, SmemLayoutC>;
+  SharedStorage& smem = *reinterpret_cast<SharedStorage*>(shared_memory);
+  Tensor sA = make_tensor(make_smem_ptr(smem.smem_C.data()), SmemLayoutA{}); // (BLK_M,BLK_K,PIPE)
+  Tensor sB = make_tensor(make_smem_ptr(smem.smem_C.data()), SmemLayoutB{}); // (BLK_N,BLK_K,PIPE)
+  Tensor sC = make_tensor(make_smem_ptr(smem.smem_C.data()), SmemLayoutC{});
+  cluster_sync();
+
+  auto threadId = threadIdx.x + threadIdx.y * blockDim.x;
+  ThrMMA thr_mma = mma.get_thread_slice_new(threadId);
+
+  // Tensor aurora_tCsA_origin = thr_mma.aurora_partition_A_v2(sA);
+  Tensor aurora_tCsA = thr_mma.aurora_partition_A_split(sA);
+
+  // Tensor aurora_tCsB_origin = thr_mma.aurora_partition_B_v2(sB);
+  Tensor aurora_tCsB = thr_mma.aurora_partition_B_split(sB);
+
+  // Tensor aurora_tCsC_origin = thr_mma.aurora_partition_C_v3(sC);
+  Tensor aurora_tCsC = thr_mma.aurora_partition_C_split(sC);
+
+  // Allocate accumulators and clear them                      
+  // Tensor aurora_tCrC_origin = thr_mma.make_fragment_C_new(aurora_tCsC_origin);  // (MMA,MMA_M,MMA_N)
+  // clear(aurora_tCrC_origin);
+  Tensor aurora_tCrC = thr_mma.make_fragment_C_new(aurora_tCsC);
+  clear(aurora_tCrC);
+
+  // Allocate "fragments"
+
+  // Tensor aurora_tCrA_origin = thr_mma.make_fragment_A(aurora_tCsA_origin);                         // (MMA,MMA_M,MMA_K,PIPE)
+  Tensor aurora_tCrA = thr_mma.make_fragment_A(aurora_tCsA);
+
+  // Tensor aurora_tCrB_origin = thr_mma.make_fragment_B(aurora_tCsB_origin);                         // (MMA,MMA_N,MMA_K,PIPE)
+  Tensor aurora_tCrB = thr_mma.make_fragment_B(aurora_tCsB);
+
+  if (thread0()) {
+
+    print("aurora_tCsA  : "); print(aurora_tCsA); print("\n");                  //(((_64,_2),(_2,_64)),_16,_1,(_2)):(((_64,_1),(_131072,_0)),_4,_0,(_262144))
+    // print("aurora_tCsA_origin  : "); print(aurora_tCsA_origin); print("\n");    //((_64,_64),_1,_1,(_2)):((_64,_1),_0,_0,(_262144))
+
+    print("aurora_tCsB  : "); print(aurora_tCsB); print("\n");
+    // print("aurora_tCsB_origin  : "); print(aurora_tCsB_origin); print("\n");
+
+    print("aurora_tCsC  : "); print(aurora_tCsC); print("\n");
+    // print("aurora_tCsC_origin  : "); print(aurora_tCsC_origin); print("\n");
+
+    print("aurora_tCrA  : "); print(aurora_tCrA); print("\n");
+    // print("aurora_tCrA_origin  : "); print(aurora_tCrA_origin); print("\n");
+
+    print("aurora_tCrB  : "); print(aurora_tCrB); print("\n");
+    // print("aurora_tCrB_origin  : "); print(aurora_tCrB_origin); print("\n");
+
+    print("aurora_tCrC  : "); print(aurora_tCrC); print("\n");
+    // print("aurora_tCrC_origin  : "); print(aurora_tCrC_origin); print("\n");
+    
+    print("---------------------\n");
+  }
+  //A:m2k8, B:n1k8, C:m2n1, so each pipeline repeat k*inner_m*inner_n = 8*2*1 = 16 times
+  gemm(mma, aurora_tCrA(_,_,_,0), aurora_tCrB(_,_,_,0), aurora_tCrC(_,_,_,0));
+  gemm(mma, aurora_tCrA(_,_,_,1), aurora_tCrB(_,_,_,1), aurora_tCrC(_,_,_,1));
+}
+
+
+
+// Setup params for an NT GEMM
+template <class TA, class TB, class TC,
+          class Alpha, class Beta>
+void
+gemm_nt(int m, int n, int k,
+        Alpha alpha,
+        TA const* A, int ldA,
+        TB const* B, int ldB,
+        Beta beta,
+        TC      * C, int ldC,
+        cudaStream_t stream = 0)
+{
+  // Define shapes (dynamic)
+  auto M = int(m);
+  auto N = int(n);
+  auto K = int(k);
+  auto prob_shape = make_shape(M, N, K);                     // (M, N, K)
+
+  auto dC = make_stride(Int<1>{}, ldC);                      // (dM, dN)
+
+  // Define CTA tile sizes (static) 128*128*128
+  auto bM = Int<256>{};
+  auto bN = Int<128>{};
+  auto bK = Int<128>{};
+  auto cta_tiler = make_shape(bM, bN, bK);                   // (BLK_M, BLK_N, BLK_K)
+  
+
+  // Define the smem layouts (static)
+
+  auto sA = tile_to_dm_shape(AMMA::Layout_DM_SW128_Atom<TA>{}, make_shape(bM,bK,bP));
+  auto sB = tile_to_dm_shape(AMMA::Layout_DM_SW128_Atom<TA>{}, make_shape(bN,bK,bP));
+  // Define the MMA
+  // TiledMMA tiled_mma = make_tiled_mma(Aurora_128x128x128_F16F16F16_APELayoutM2N2K1_SS<AMMA::Major::MN,AMMA::Major::MN>{});
+  TiledMMA tiled_mma = make_tiled_mma(Aurora_64x64x16_F16F16F16_APELayoutM2N2K1_SS<AMMA::Major::MN,AMMA::Major::MN>{});
+  auto sC = tiled_mma.tile_to_dm_shape(make_shape(bM, bN, bP));
+  print("sA:  ");print(sA);print("\n");
+  print("sB:  ");print(sB);print("\n");
+  print("sC:  ");print(sC);print("\n");
+  // Launch parameter setup
+  int smem_size = int(sizeof(SharedStorage<TC, decltype(sC)>));
+  auto ape_shape = get_ape_shape_mnk(tiled_mma);
+  dim3 dimBlock(get<0>(ape_shape), get<1>(ape_shape), get<2>(ape_shape));
+  print("dimBlock  : "); print(dimBlock); print("\n");
+  dim3 dimCluster(1, 1, 1);
+  dim3 dimGrid(round_up(size(ceil_div(m, bM)), dimCluster.x),
+               round_up(size(ceil_div(n, bN)), dimCluster.y));
+  cutlass::ClusterLaunchParams params = {dimGrid, dimBlock, dimCluster, smem_size};
+
+  void const* kernel_ptr = reinterpret_cast<void const*>(
+                              &gemm_device<decltype(prob_shape), decltype(cta_tiler),
+                                           decltype(sA),
+                                           decltype(sB),decltype(sC),
+                                           TC, decltype(dC), decltype(tiled_mma)>);
+
+  CUTE_CHECK_ERROR(cudaFuncSetAttribute(
+    kernel_ptr,
+    cudaFuncAttributeMaxDynamicSharedMemorySize,
+    smem_size));
+
+  // Kernel Launch
+  cutlass::Status status = cutlass::launch_kernel_on_cluster(params, kernel_ptr,
+                                                             prob_shape, cta_tiler,
+                                                             C, dC, tiled_mma);
+  CUTE_CHECK_LAST();
+
+  if (status != cutlass::Status::kSuccess) {
+    std::cerr << "Error: Failed at kernel Launch" << std::endl;
+  }
+}
+
+
+
+int main(int argc, char** argv)
+{
+    int m = 256;
+    int n = 256;
+    int k = 256;
+    using TA = cute::half_t;
+    using TB = cute::half_t;
+    using TC = cute::half_t;
+    using TI = cute::half_t;
+    TI alpha = TI(1.0f);
+    TI beta  = TI(0.0f);
+    thrust::host_vector<TA> h_A(m*k);
+    thrust::host_vector<TB> h_B(n*k);
+    thrust::host_vector<TC> h_C(m*n);
+    for (int j = 0; j < m*k; ++j) h_A[j] = TA(int((rand() % 2) ? 1 : -1));
+    for (int j = 0; j < n*k; ++j) h_B[j] = TB(int((rand() % 2) ? 1 : -1));
+    for (int j = 0; j < m*n; ++j) h_C[j] = TC(0);
+    thrust::device_vector<TA> d_A = h_A;
+    thrust::device_vector<TB> d_B = h_B;
+    thrust::device_vector<TC> d_C = h_C;
+    int ldA = 0, ldB = 0, ldC = m;
+    ldA = m;
+    ldB = n;
+    gemm_nt(m, n, k, alpha,
+            d_A.data().get(), ldA,
+            d_B.data().get(), ldB,
+            beta,
+            d_C.data().get(), ldC);
+}

--- a/include/cute/arch/mma_aurora_gmma.hpp
+++ b/include/cute/arch/mma_aurora_gmma.hpp
@@ -421,6 +421,81 @@ struct MMA_Aurora_128x128x128_F16F16F16_APELayoutM1N1K1_SS
   }
 };
 
+//64*64*16 F16
+template <
+  AMMA::Major tnspA,
+  AMMA::Major tnspB,
+  AMMA::ScaleIn  scaleA = AMMA::ScaleIn::One,
+  AMMA::ScaleIn  scaleB = AMMA::ScaleIn::One
+>
+struct MMA_Aurora_64x64x16_F16F16F16_APELayoutM2N2K1_SS
+{
+  using DRegisters = void;
+  using ARegisters = uint64_t[32];
+  using BRegisters = uint64_t[32];
+  using CRegisters = uint32_t[8];
+
+  CUTE_HOST_DEVICE static void
+  gemm_cal(uint16_t const alpha, 
+           uint32_t const m, 
+           uint32_t const n, 
+           uint32_t const k,
+           void* const MatrixA, 
+           void* const MatrixB, 
+           void* const MatrixC){
+            {
+              uint y = threadIdx.y + blockIdx.y * blockDim.y;
+              uint x = threadIdx.x + blockIdx.x * blockDim.x + gridDim.x * blockDim.x * y;
+              if (x == 0)
+              {
+                printf("in gemm_cal 128*128*128 (not compatibale). ");
+                printf("alpha:%u, m:%u, n:%u, k:%u", alpha, m, n, k);
+                printf("MatrixA:%p, MatrixB:%p, MatrixC:%p\n", MatrixA, MatrixB, MatrixC);
+                printf("\n\n");
+              }
+            }
+            //call spu
+  }
+
+  CUTE_HOST_DEVICE static void
+  fma(uint64_t const& desc_a,
+      uint64_t const& desc_b,
+      uint32_t      & d00, uint32_t      & d01, uint32_t      & d02, uint32_t      & d03,
+      uint32_t      & d04, uint32_t      & d05, uint32_t      & d06, uint32_t      & d07,
+      uint32_t      & d08, uint32_t      & d09, uint32_t      & d10, uint32_t      & d11,
+      uint32_t      & d12, uint32_t      & d13, uint32_t      & d14, uint32_t      & d15,
+      AMMA::ScaleOut const scale_D = AMMA::ScaleOut::One)
+  {
+    if(threadIdx.x == 0 && blockIdx.x == 0){
+      printf("hello 128*128*64.\n");
+    }
+#if defined(CUTE_ARCH_MMA_SM90A_ENABLED)
+    // cutlass::arch::synclog_emit_wgmma_smem_smem(__LINE__, desc_a, desc_b);
+    // asm volatile(
+    // "{\n"
+    //   ".reg .pred p;\n"
+    //   "setp.ne.b32 p, %18, 0;\n"
+    //   "wgmma.mma_async.sync.aligned.m64n64k16.f16.f16.f16 "
+    //   "{%0,  %1,  %2,  %3,  %4,  %5,  %6,  %7,  "
+    //   " %8,  %9,  %10, %11, %12, %13, %14, %15},"
+    //   " %16,"
+    //   " %17,"
+    //   " p,   %19, %20, %21, %22;\n"
+    // "}\n"
+    //   : "+r"(d00), "+r"(d01), "+r"(d02), "+r"(d03),
+    //     "+r"(d04), "+r"(d05), "+r"(d06), "+r"(d07),
+    //     "+r"(d08), "+r"(d09), "+r"(d10), "+r"(d11),
+    //     "+r"(d12), "+r"(d13), "+r"(d14), "+r"(d15)
+    //   :  "l"(desc_a),
+    //      "l"(desc_b),
+    //      "r"(int32_t(scale_D)), "n"(int32_t(scaleA)), "n"(int32_t(scaleB)), "n"(int32_t(tnspA)), "n"(int32_t(tnspB)));
+#else
+    CUTE_INVALID_CONTROL_PATH("Attempting to use MMA_Aurora_F16F16F16_SS without CUTE_ARCH_MMA_SM90A_ENABLED");
+#endif
+  }
+};
+
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 } // namespace SM90::GMMA

--- a/include/cute/atom/mma_atom.hpp
+++ b/include/cute/atom/mma_atom.hpp
@@ -163,7 +163,7 @@ struct MMA_Atom<MMA_Traits<MMAOperation, Args...>>
                         || (sizeof_bits_v<typename remove_cvref_t<CTensor>::value_type> == 8 &&
                             (sizeof_bits_v<ValTypeC> == 8 || sizeof_bits_v<ValTypeC> == 6 || sizeof_bits_v<ValTypeC> == 4))
                       , "Expecting ValTypeC type");
-#if 1
+#if 0
     if(thread0()){
       auto Ac = AuroraFrgTypeC{};
       print("in make_fragment_C_v2.\n");
@@ -365,6 +365,70 @@ struct TiledMMA : MMA_Atom
     return split_tensor;
   }
 
+  /**
+   * split input tensor acoording to (atomM, atomN) or nor.
+   * 1 if problem shape in DM <= (atomM, atomN), we do not split, and the res is ((thrM, thrN), (probM, probN), _1, _1, (PIPE))
+   * 2 if problem shape in DM > (atomM, atomN), we split atensor into ((thrM, thrN), (atomM, atomN), restM, restN, (PIPE))
+   */
+  template <class CTensor>
+  CUTE_HOST_DEVICE constexpr
+  auto
+  aurora_thrfrg_C_split(CTensor&& ctensor) const
+  {
+    CUTE_STATIC_ASSERT_V(rank(ctensor) >= Int<2>{});
+    auto atomM = size<0>(AtomShape_MNK{});
+    auto atomN = size<1>(AtomShape_MNK{});
+    auto original_m = size<0,0>(shape(ctensor));
+    auto original_n = size<0,1>(shape(ctensor));
+    
+    //(original_m, original_n) (atomM, atomN) should satisfy the following 2 conditions
+    static_assert(!(original_m > atomM && original_n < atomN), "Condition: original_m > atomM and original_n < atomN is invalid");
+    static_assert(!(original_m < atomM && original_n > atomN), "Condition: original_m < atomM and original_n > atomN is invalid");
+    
+    //split original problem according to mma_atom only if (original_m, original_n) > (atomM, atomN)
+    using TileType = std::conditional_t<
+            (original_m <= atomM && original_n <= atomN),
+            decltype(make_tile(original_m, original_n)),
+            decltype(make_tile(atomM, atomN))
+        >;
+    TileType t_tile;
+
+    auto t_tensor = zipped_divide(get<0>(ctensor), t_tile);                
+    //adjust
+    auto inter_tensor = replace<0>(ctensor, t_tensor);
+
+    //flatten coord
+    auto flat_coord = flatten(get<0,1>(inter_tensor));
+
+    auto thr_layout_tensor = get<1>(inter_tensor);    //(ThrM, ThrN)
+    static_assert(shape(thr_layout_tensor) == shape(select<0,1>(AtomAuroraThrLayout_MNK{})), "(ThrM, ThrN) in ctensor must be equal with (M,N) in AtomAuroraThrLayout_MNK.");
+    
+    auto atom_tensor = get<0,0>(inter_tensor);
+    auto atom_in_M = get<0>(flat_coord);
+    auto atom_in_N = get<1>(flat_coord);
+    auto pipeline_tensor = get<2>(inter_tensor);
+
+    //composition
+    auto thr_tensor = make_layout(thr_layout_tensor, atom_tensor, atom_in_M, atom_in_N, pipeline_tensor);
+
+#if 0
+    if(thread0()){
+      print("\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\n");
+      print("aurora_thrfrag_A_split:\n");
+      print("original_m:");print(original_m);print("\n");
+      print("original_n:");print(original_n);print("\n");
+      print("ctensor:");print(ctensor);print("\n");
+      print("t_tile:");print(t_tile);print("\n");
+      print("t_tensor:");print(t_tensor);print("\n");
+      print("inter_tensor:");print(inter_tensor);print("\n");
+      print("flat_coord:");print(flat_coord);print("\n");
+      print("thr_tensor:");print(thr_tensor);print("\n");
+      print("\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\n\n");
+    }
+#endif
+    return thr_tensor;
+  }
+
   // Tile a tensor or a layout from shape
   //   (M,K,...)
   // to shape
@@ -404,6 +468,78 @@ struct TiledMMA : MMA_Atom
     return thr_tensor;
   }
 
+  /**
+   * split input tensor acoording to (atomM, atomK) or nor.
+   * 1 if problem shape in DM <= (atomM, atomK), we do not split, and the res is ((thrM, thrK), (probM, probK), _1, _1, (PIPE))
+   * 2 if problem shape in DM > (atomM, atomK), we split atensor into ((thrM, thrK), (atomM, atomK), restM, restK, (PIPE))
+   */
+  template <class ATensor>
+  CUTE_HOST_DEVICE constexpr
+  auto
+  aurora_thrfrg_A_split(ATensor&& atensor) const
+  {
+    CUTE_STATIC_ASSERT_V(rank(atensor) >= Int<2>{});
+    auto atomM = size<0>(AtomShape_MNK{});
+    auto atomK = size<2>(AtomShape_MNK{});
+    auto original_m = size<0,0>(shape(atensor));
+    auto original_k = size<0,1>(shape(atensor));
+
+    //must satisfy the following 2 conditions
+    static_assert(!(original_m > atomM && original_k < atomK), "Condition: original_m > atomM and original_k < atomK is invalid");
+    static_assert(!(original_m < atomM && original_k > atomK), "Condition: original_m < atomM and original_k > atomK is invalid");
+    
+    using TileType = std::conditional_t<
+            (original_m <= atomM && original_k <= atomK),
+            decltype(make_tile(original_m, original_k)),
+            decltype(make_tile(atomM, atomK))
+        >;
+    TileType t_tile;
+  
+    auto t_tensor = zipped_divide(get<0>(atensor), t_tile);     //(atomM, atomK), (restM, restK)            
+
+    //adjust
+    auto inter_tensor = replace<0>(atensor, t_tensor);          //(((atomM, atomK), (restM, restK)), (ThrM, ThrK), (PIPE))
+
+    //flatten coord
+    auto flat_coord = flatten(get<0,1>(inter_tensor));         //(restM, restK)
+
+    
+    auto thr_layout_tensor = get<1>(inter_tensor);            //(ThrM, ThrK)
+    static_assert(shape(thr_layout_tensor) == shape(select<0,2>(AtomAuroraThrLayout_MNK{})), "(ThrM, ThrK) in atensor must be equal with (M,K) in AtomAuroraThrLayout_MNK.");
+    
+    auto atom_tensor = get<0,0>(inter_tensor);
+    auto atom_in_M = get<0>(flat_coord);
+    auto atom_in_K = get<1>(flat_coord);
+    auto pipeline_tensor = get<2>(inter_tensor);
+
+    //composition
+    auto thr_tensor = make_layout(thr_layout_tensor, atom_tensor, atom_in_M, atom_in_K, pipeline_tensor);
+
+#if 0
+    if(thread0()){
+      print("\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\n");
+      print("aurora_thrfrag_A_split:\n");
+      print("original_m:");print(original_m);print("\n");
+      print("original_k:");print(original_k);print("\n");
+      print("atensor:");print(atensor);print("\n");
+      print("t_tile:");print(t_tile);print("\n");
+      print("t_tensor:");print(t_tensor);print("\n");
+      print("inter_tensor:");print(inter_tensor);print("\n");
+      print("flat_coord:");print(flat_coord);print("\n");
+
+      print("thr_layout_tensor:");print(thr_layout_tensor);print("\n");
+      print("atom_tensor:");print(atom_tensor);print("\n");
+      print("atom_in_M:");print(atom_in_M);print("\n");
+      print("atom_in_K:");print(atom_in_K);print("\n");
+      print("pipeline_tensor:");print(pipeline_tensor);print("\n");
+
+      print("thr_tensor:");print(thr_tensor);print("\n"); //thr_tensor:((_1,(_4,_1)),((_64,_16),(_1,_1,_2))):((_0,(_64,_0)),((_1,_256),(_0,_0,_4096)))
+      print("\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\n\n");
+    }
+#endif
+    return thr_tensor;
+  }
+
   // Tile a tensor or a layout from shape
   //   (N,K,...)
   // to shape
@@ -440,6 +576,70 @@ struct TiledMMA : MMA_Atom
                                         make_layout(size<3>(thr_layout_vmnk_))));
     auto thr_tensor = zipped_divide(tv_tensor, thr_tile);            // ((ThrV,(ThrN,ThrK)),(FrgV,(RestN,RestK)))
 
+    return thr_tensor;
+  }
+
+  /**
+   * split input tensor acoording to (atomN, atomK) or nor.
+   * 1 if problem shape in DM <= (atomN, atomK), we do not split, and the res is ((thrN, thrK), (probN, probK), _1, _1, (PIPE))
+   * 2 if problem shape in DM > (atomN, atomK), we split atensor into ((thrN, thrK), (atomN, atomK), restN, restK, (PIPE))
+   */
+  template <class BTensor>
+  CUTE_HOST_DEVICE constexpr
+  auto
+  aurora_thrfrg_B_split(BTensor&& btensor) const
+  {
+    CUTE_STATIC_ASSERT_V(rank(btensor) >= Int<2>{});
+    auto atomN = size<1>(AtomShape_MNK{});
+    auto atomK = size<2>(AtomShape_MNK{});
+    auto original_n = size<0,0>(shape(btensor));
+    auto original_k = size<0,1>(shape(btensor));
+
+    //must satisfy the following 2 conditions
+    static_assert(!(original_n > atomN && original_k < atomK), "Condition: original_n > atomN and original_k < atomK is invalid");
+    static_assert(!(original_n < atomN && original_k > atomK), "Condition: original_n < atomN and original_k > atomK is invalid");
+    
+    //split original problem according to mma_atom only if (original_m, original_n) > (atomM, atomN)
+    using TileType = std::conditional_t<
+            (original_n <= atomN && original_k <= atomK),
+            decltype(make_tile(original_n, original_k)),
+            decltype(make_tile(atomN, atomK))
+        >;
+    TileType t_tile;
+
+    auto t_tensor = zipped_divide(get<0>(btensor), t_tile);             //((atomM, atomK), (restM, restK))     
+    //adjust
+    auto inter_tensor = replace<0>(btensor, t_tensor);                  //((atomM, atomK), (restM, restK)),(ThrM, ThrN),(PIPE)
+
+    //flatten coord
+    auto flat_coord = flatten(get<0,1>(inter_tensor));                 //(atomM, atomK)
+
+    auto thr_layout_tensor = get<1>(inter_tensor);                     //(ThrN, ThrK)
+    static_assert(shape(thr_layout_tensor) == shape(select<1,2>(AtomAuroraThrLayout_MNK{})), "(ThrN, ThrK) in btensor must be equal with (N,K) in AtomAuroraThrLayout_MNK.");
+
+    auto atom_tensor = get<0,0>(inter_tensor);
+    auto atom_in_N = get<0>(flat_coord);
+    auto atom_in_K = get<1>(flat_coord);
+    auto pipeline_tensor = get<2>(inter_tensor);
+
+    //composition
+    auto thr_tensor = make_layout(thr_layout_tensor, atom_tensor, atom_in_N, atom_in_K, pipeline_tensor);
+
+#if 0
+    if(thread0()){
+      print("\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\n");
+      print("aurora_thrfrag_B_split:\n");
+      print("original_n:");print(original_n);print("\n");
+      print("original_k:");print(original_k);print("\n");
+      print("btensor:");print(btensor);print("\n");
+      print("t_tile:");print(t_tile);print("\n");
+      print("t_tensor:");print(t_tensor);print("\n");
+      print("inter_tensor:");print(inter_tensor);print("\n");
+      print("flat_coord:");print(flat_coord);print("\n");
+      print("thr_tensor:");print(thr_tensor);print("\n"); //thr_tensor:((_1,(_4,_1)),((_64,_16),(_1,_1,_2))):((_0,(_64,_0)),((_1,_256),(_0,_0,_4096)))
+      print("\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\n\n");
+    }
+#endif
     return thr_tensor;
   }
 
@@ -676,42 +876,6 @@ struct TiledMMA : MMA_Atom
     return make_layout(begin_layout, intermedia_layout, final_layout);
   }
 
-  /**
-   * split (bM, bN) into (bM/m, bN/n),(m,n)
-   */
-//   template <class Shape>
-//   CUTE_HOST_DEVICE constexpr
-//   auto
-//   tile_to_dm_shape(Shape const& trg_shape){
-//     auto atom_thr = AtomAuroraThrLayout_MNK{};
-
-//     //split to 2*2
-//     auto splitM = size<0>(atom_thr);
-//     auto splitN = size<1>(atom_thr);
-
-//     auto calM = size<0>(shape(ctensor))/splitM;
-//     auto calN = size<1>(shape(ctensor))/splitN;
-
-//     auto t_tile = make_tile(calM, calN);
-//     auto t_tensor = zipped_divide(trg_shape, t_tile);
-
-//     auto help_layout = make_layout(make_shape(_1{}, _1{}), make_stride(_0{}, _0{}));
-//     auto split_tensor = make_layout(
-//                       get<1>(t_tensor),
-//                       get<0>(t_tensor),
-//                       get<0>(help_layout),
-//                       get<1>(help_layout)
-//                       );
-// #if 1
-//     if(thread0()){
-//       print("trg_shape:");print(trg_shape);print("\n");
-//       print("atom_thr:");print(atom_thr);print("\n");
-//       print("t_tensor:");print(t_tensor);print("\n");
-//       print("split_tensor:");print(split_tensor);print("\n");
-//     }
-// #endif
-//     return 
-//   }
 };
 
 template <class TiledMMA, class ThrVMNK>
@@ -791,10 +955,6 @@ struct ThrMMA : TiledMMA
   auto
   aurora_partition_C_v3(CTensor&& ctensor) const
   {
-    // auto target_tensor = make_layout(
-    //       make_shape(make_shape(_64{}, _64{}), make_shape(_2{}, _2{}), _2{}),
-    //       make_stride(make_stride(_1{}, _64{}), make_stride(_65536{}, _131072{}), _262144{})
-    //   );
     auto target_tensor = ctensor;
     auto help_layout = make_layout(make_shape(_1{}, _1{}), make_stride(_0{}, _0{}));
     auto res_layout = make_layout(get<1>(target_tensor.layout()), 
@@ -823,6 +983,31 @@ struct ThrMMA : TiledMMA
 
     // return ctensor;
     return res_test;
+  }
+
+  
+  template <class CTensor>
+  CUTE_HOST_DEVICE constexpr
+  auto
+  aurora_partition_C_split(CTensor&& ctensor) const
+  {
+    auto thr_tensor_res = make_tensor(static_cast<CTensor&&>(ctensor).data(), this->aurora_thrfrg_C_split(ctensor.layout()));
+    auto thr_mk = make_coord(get<1>(thr_vmnk_), get<2>(thr_vmnk_));
+    auto res = thr_tensor_res(make_coord(thr_mk, _, _, _, _));
+#if 0
+    if(thread0()){
+      auto rt = repeat<rank<1,1>(thr_tensor_res)>(_);
+      auto md = make_coord(_, repeat<rank<1,1>(thr_tensor_res)>(_));
+
+      print("in partition_A_v5 thread0:\n");
+      print("rt:");print(rt);print("\n");   //rt:(_,_,_)
+      print("md:");print(md);print("\n");   //md:(_,(_,_,_))
+      print("thr_tensor_res:");print(thr_tensor_res);print("\n");
+      print("res:");print(res);print("\n");
+      print("\n\n");
+    }
+#endif
+    return res;
   }
 
   template <class ATensor>
@@ -860,6 +1045,30 @@ struct ThrMMA : TiledMMA
       print("target_tensor:");print(target_tensor);print("\n");
       print("res_layout:");print(res_layout);print("\n");
       print("thr_mk:");print(thr_mk);print("\n");
+      print("res:");print(res);print("\n");
+      print("\n\n");
+    }
+#endif
+    return res;
+  }
+
+  template <class ATensor>
+  CUTE_HOST_DEVICE constexpr
+  auto
+  aurora_partition_A_split(ATensor&& atensor) const
+  {
+    auto thr_tensor_res = make_tensor(static_cast<ATensor&&>(atensor).data(), this->aurora_thrfrg_A_split(atensor.layout()));
+    auto thr_mk = make_coord(get<1>(thr_vmnk_), get<3>(thr_vmnk_));
+    auto res = thr_tensor_res(make_coord(thr_mk, _, _, _, _));
+#if 0
+    if(thread0()){
+      auto rt = repeat<rank<1,1>(thr_tensor_res)>(_);
+      auto md = make_coord(_, repeat<rank<1,1>(thr_tensor_res)>(_));
+
+      print("in partition_A_v5 thread0:\n");
+      print("rt:");print(rt);print("\n");   //rt:(_,_,_)
+      print("md:");print(md);print("\n");   //md:(_,(_,_,_))
+      print("thr_tensor_res:");print(thr_tensor_res);print("\n");
       print("res:");print(res);print("\n");
       print("\n\n");
     }
@@ -905,6 +1114,31 @@ struct ThrMMA : TiledMMA
     print("thr_mk:");print(thr_mk);print("\n");
     print("res:");print(res);print("\n");
     print("\n\n");
+    }
+#endif
+    return res;
+  }
+
+  template <class BTensor>
+  CUTE_HOST_DEVICE constexpr
+  auto
+  aurora_partition_B_split(BTensor&& btensor) const
+  {
+    auto thr_tensor_res = make_tensor(static_cast<BTensor&&>(btensor).data(), this->aurora_thrfrg_B_split(btensor.layout()));
+
+    auto thr_mk = make_coord(get<2>(thr_vmnk_), get<3>(thr_vmnk_));
+    auto res = thr_tensor_res(make_coord(thr_mk, _, _, _, _));
+#if 0
+    if(thread0()){
+      auto rt = repeat<rank<1,1>(thr_tensor_res)>(_);
+      auto md = make_coord(_, repeat<rank<1,1>(thr_tensor_res)>(_));
+
+      print("in partition_B_split:\n");
+      print("rt:");print(rt);print("\n");   //rt:(_,_,_)
+      print("md:");print(md);print("\n");   //md:(_,(_,_,_))
+      print("thr_tensor_res:");print(thr_tensor_res);print("\n");
+      print("res:");print(res);print("\n");
+      print("\n\n");
     }
 #endif
     return res;

--- a/include/cute/atom/mma_traits_aurora_gmma.hpp
+++ b/include/cute/atom/mma_traits_aurora_gmma.hpp
@@ -882,6 +882,46 @@ struct MMA_Traits<Aurora_128x128x128_F16F16F16_APELayoutM1N1K1_SS<tnspA, tnspB, 
   using AuroraDMLayout_MN = Layout<Shape<_1, _1>>;
   AMMA::ScaleOut accumulate_ = AMMA::ScaleOut::One;
 };
+
+template <
+  AMMA::Major tnspA,
+  AMMA::Major tnspB,
+  AMMA::ScaleIn  scaleA = AMMA::ScaleIn::One,
+  AMMA::ScaleIn  scaleB = AMMA::ScaleIn::One
+>
+using Aurora_64x64x16_F16F16F16_APELayoutM2N2K1_SS = AMMA::MMA_Aurora_64x64x16_F16F16F16_APELayoutM2N2K1_SS<tnspA, tnspB, scaleA, scaleB>;
+
+template <AMMA::Major tnspA, AMMA::Major tnspB, AMMA::ScaleIn scaleA, AMMA::ScaleIn scaleB>
+struct MMA_Traits<Aurora_64x64x16_F16F16F16_APELayoutM2N2K1_SS<tnspA, tnspB, scaleA, scaleB>>
+{
+  using ValTypeD = half_t;
+  using ValTypeA = half_t;
+  using ValTypeB = half_t;
+  using ValTypeC = half_t;
+
+  using FrgTypeA = AMMA::dm_desc<tnspA>;                //dm descriptor iterator
+  using FrgTypeB = AMMA::dm_desc<tnspB>;
+  using AuroraFrgTypeC = AMMA::dm_desc<tnspA>;
+  
+  using Shape_MNK = Shape<_64,_64,_16>;
+  using ThrID   = Layout<_1>;                           //to calculate a mma_atom only needs 1 thread
+  // using ThrID   = Layout<Shape<_2, _2, _1>>;
+  using ALayout = AMMA::ABLayout< 64, 16>;
+  using BLayout = AMMA::ABLayout< 64, 16>;
+  using CLayout = AMMA::CLayout_64x64;
+
+  using Split_MNK = decltype(make_tuple(Int<4>{}, Int<1>{}, Int<1>{}));
+  /**
+   * APE layout is 2*2*1, which means we split A to 2*1, B to 2*1, C to 2*2 for an CTA.
+   * layout_MNK=2 2 1
+   * 
+   */
+  using AuroraThrLayout_MNK = Layout<Shape<_2, _2, _1>>;   
+  using AuroraDMLayout_MN = Layout<Shape<_2, _2>, Stride<Int<131072>, Int<262144>>>;
+
+  AMMA::ScaleOut accumulate_ = AMMA::ScaleOut::One;
+};
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 } // end namespace cute


### PR DESCRIPTION
提供一套mma API，形如aurora_partition_X_split用于按照MMA_ATOM切割DM：
1 aurora_partition_X_split会判断放入DM的problem_shape和atom_shape，按照两者中更小的进行切割。如果调用了_split类API，用户必须考虑清楚使用哪个mma_atom
2 该API为可选使用，以DM的proble_shape为spu计算整体可能会更简单。